### PR TITLE
More meet command goodies: setting duration of meeting

### DIFF
--- a/src/main/java/seedu/address/logic/commands/MeetCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MeetCommand.java
@@ -2,12 +2,14 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
+import java.util.function.BinaryOperator;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
@@ -37,44 +39,44 @@ public class MeetCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1 4 5";
     public static final String MESSAGE_DUPLICATE_EVENT = "Operation would result in similar events."
             + " Change parameters and run command again.";
+    public static final String MESSAGE_CANNOT_FIND_MEETING_EVENT = "Cannot find a suitabe timeslot.\n"
+            + "Please suggest different parameters, perhaps a later end time.";
 
     private List<Index> indices;
-    private List<Person> listOfPeopleSelected;
     private Name name;
     private Description description;
     private Venue venue;
     private DateTime start;
     private DateTime end;
     private Label label;
+    private Duration duration;
 
     /**
      * Creates a MeetCommand using a Set of integers based on the one-based index.
      * @param indices The set of integers to be processed.
      */
     public MeetCommand(Set<Integer> indices, Name name, Description description, Venue venue, DateTime start,
-                       DateTime end, Label label) {
+                       DateTime end, Label label, Duration d) {
         requireNonNull(indices);
         this.indices = new ArrayList<>();
         for (Integer i : indices) {
             this.indices.add(Index.fromOneBased(i));
         }
-        this.listOfPeopleSelected = new ArrayList<>();
         this.name = name;
         this.description = description;
         this.venue = venue;
         this.start = start;
         this.end = end;
         this.label = label;
+        this.duration = d;
     }
 
     @Override
     public CommandResult execute(Model model, CommandHistory history, WindowViewState windowViewState)
             throws CommandException {
-        // Create the command result.
-        requireNonNull(model);
 
-        // Default meeting length set as 2 hours.
-        long meetingLength = 2;
+        // Model must exist.
+        requireNonNull(model);
 
         // Get the people that need to be operated on.
         List<Person> listOfPeopleShown = model.getFilteredPersonList();
@@ -86,43 +88,62 @@ public class MeetCommand extends Command {
         } catch (IndexOutOfBoundsException e) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
+
+        /*
+         * Check if the user requested for a possible start date that is before the current time.
+         * If the date time entered is before the current time, set the earliest event time to be
+         * the current time instead.
+         */
         if (toDateTime(start).isBefore(LocalDateTime.now())) {
             start = new DateTime(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
         }
+
         Event meeting = new Event(name, description, venue,
                 start,
-                new DateTime(toDateTime(start).plusHours(meetingLength).format(DateTimeFormatter
+                new DateTime(toDateTime(start).plus(duration).format(DateTimeFormatter
                         .ofPattern("yyyy-MM-dd HH:mm:ss"))),
                 label);
 
-        Event meetingEvent = model.getFilteredEventList()
-                .stream()
-                .filter(e -> {
-                    for (Person p : personsOperatedOn) {
-                        if (e.hasPerson(p)) {
-                            return true;
+        if (toDateTime(meeting.getEndDateTime()).isAfter(toDateTime(end))) {
+            throw new CommandException(MESSAGE_CANNOT_FIND_MEETING_EVENT);
+        }
+        Event meetingEvent;
+        try {
+            meetingEvent = model.getFilteredEventList()
+                    .stream()
+                    .filter(e -> {
+                        for (Person p : personsOperatedOn) {
+                            if (e.hasPerson(p)) {
+                                return true;
+                            }
                         }
-                    }
-                    return false;
-                })
-                .sorted(new EventComparator())
-                .reduce(meeting, (x, y) -> {
-                    LocalDateTime xEnd = toDateTime(x.getEndDateTime());
-                    LocalDateTime yStart = toDateTime(y.getStartDateTime());
-                    LocalDateTime yEnd = toDateTime(y.getEndDateTime());
-                    if (toDateTime(x.getStartDateTime()).isAfter(yEnd)
-                            || !xEnd.isAfter(yStart)) {
-                        return x;
-                    }
-                    LocalDateTime start = yEnd;
-                    if (xEnd.isAfter(yEnd)) {
-                        start = xEnd;
-                    }
-                    return new Event(name, description, venue,
-                            new DateTime(start.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))),
-                            new DateTime(start.plusHours(meetingLength).format(DateTimeFormatter
-                                    .ofPattern("yyyy-MM-dd HH:mm:ss"))), label);
-                });
+                        return false;
+                    })
+                    .sorted(new EventComparator())
+                    .reduce(meeting, (ExceptionalBinaryOperator<Event>) (x, y) -> {
+                        LocalDateTime xEnd = toDateTime(x.getEndDateTime());
+                        if (xEnd.isAfter(toDateTime(end))) {
+                            throw new CommandException(MESSAGE_CANNOT_FIND_MEETING_EVENT);
+                        }
+                        LocalDateTime yStart = toDateTime(y.getStartDateTime());
+                        LocalDateTime yEnd = toDateTime(y.getEndDateTime());
+                        if (toDateTime(x.getStartDateTime()).isAfter(yEnd)
+                                || !xEnd.isAfter(yStart)) {
+                            return x;
+                        }
+                        LocalDateTime start = yEnd;
+                        if (xEnd.isAfter(yEnd)) {
+                            start = yEnd;
+                        }
+                        return new Event(name, description, venue,
+                                new DateTime(start.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))),
+                                new DateTime(start.plus(duration).format(DateTimeFormatter
+                                        .ofPattern("yyyy-MM-dd HH:mm:ss"))), label);
+                    });
+        } catch (RuntimeException e) {
+            throw new CommandException(e.getMessage());
+        }
+
         meetingEvent.addPerson(personsOperatedOn.toArray(new Person[0]));
         model.updateFilteredEventList(x -> true);
         for (Event e : model.getFilteredEventList()) {
@@ -152,5 +173,37 @@ public class MeetCommand extends Command {
             return LocalDateTime.parse(e1.getStartDateTime().toString(), pattern).compareTo(
                     LocalDateTime.parse(e2.getStartDateTime().toString(), pattern));
         }
+    }
+
+    /**
+     * Functional interface to allow lambda expressions to throw exceptions.
+     * @param <T> The type that the BinaryOperator will apply on.
+     */
+    @FunctionalInterface
+    interface ExceptionalBinaryOperator<T> extends BinaryOperator<T> {
+
+        /**
+         * Applies the function on two objects of type T.
+         * @param t The first object.
+         * @param u The second object.
+         * @return The resulting object.
+         */
+        default T apply(T t, T u) {
+            try {
+                return applyThrows(t, u);
+            } catch (final CommandException e) {
+                throw new RuntimeException(e.getMessage());
+            }
+        }
+
+        /**
+         * Apply method to be overriden by lambda expression that allows
+         * throwing of a CommandException.
+         * @param t The first operand.
+         * @param u The second operand.
+         * @return The resulting object.
+         * @throws CommandException If the lambda expression explicitly throws an exception.
+         */
+        T applyThrows(T t, T u) throws CommandException;
     }
 }

--- a/src/main/java/seedu/address/logic/parser/MeetCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/MeetCommandParser.java
@@ -4,12 +4,14 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DURATION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_END_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LABEL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_START_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_VENUE;
 
+import java.time.Duration;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Stream;
@@ -40,7 +42,7 @@ public class MeetCommandParser implements Parser<MeetCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_DESCRIPTION, PREFIX_VENUE, PREFIX_START_TIME,
-                        PREFIX_END_TIME, PREFIX_LABEL);
+                        PREFIX_END_TIME, PREFIX_LABEL, PREFIX_DURATION);
 
         // remove leading and trailing white space
         String trimmedArgs = args.trim();
@@ -60,8 +62,10 @@ public class MeetCommandParser implements Parser<MeetCommand> {
         DateTime startTime = ParserUtilForEvent.parseDateTime(argMultimap.getValue(PREFIX_START_TIME)
                 .orElse("0001-01-01 00:00:00"));
         DateTime endTime = ParserUtilForEvent.parseDateTime(argMultimap.getValue(PREFIX_END_TIME)
-                .orElse("0001-01-01 00:00:00"));
+                .orElse("9999-12-31 23:59:59"));
         Label label = ParserUtilForEvent.parseLabel(argMultimap.getValue(PREFIX_LABEL).orElse("meeting"));
+        Duration duration = ParserUtilForEvent.parseDuration(argMultimap.getValue(PREFIX_DURATION)
+                .orElse("0 2 0 0"));
 
         Set<Integer> indices = new TreeSet<>();
         try {
@@ -78,7 +82,7 @@ public class MeetCommandParser implements Parser<MeetCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, MeetCommand.MESSAGE_USAGE));
         }
 
-        return new MeetCommand(indices, name, description, venue, startTime, endTime, label);
+        return new MeetCommand(indices, name, description, venue, startTime, endTime, label, duration);
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtilForEvent.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtilForEvent.java
@@ -2,6 +2,9 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -17,6 +20,8 @@ import seedu.address.model.event.Venue;
 public class ParserUtilForEvent {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    public static final String MESSAGE_INVALID_DURATION = "Duration must be in the format D H M S"
+        + " and must be non-negative.";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -104,6 +109,30 @@ public class ParserUtilForEvent {
             throw new ParseException(Label.MESSAGE_CONSTRAINTS);
         }
         return new Label(trimmedLabel);
+    }
+
+    /**
+     * Parses a {@code String duration} into a {@code Duration}.
+     * @param duration The string to be parsed into a duration.
+     * @return The resulting duration.
+     * @throws ParseException If the duration entered throws a DateTimeParseException
+     *                        or if there are not enough arguments provided or the duration
+     *                        is negative.
+     */
+    public static Duration parseDuration(String duration) throws ParseException {
+        requireNonNull(duration);
+        String[] trimmedDuration = duration.trim().split(" ");
+        Duration d;
+        try {
+            d = Duration.parse(String.format("P%sDT%sH%sM%s.0S", trimmedDuration[0],
+                    trimmedDuration[1], trimmedDuration[2], trimmedDuration[3]));
+            if (d.isNegative()) {
+                throw new ParseException(MESSAGE_INVALID_DURATION);
+            }
+        } catch (DateTimeParseException | IndexOutOfBoundsException e) {
+            throw new ParseException(MESSAGE_INVALID_DURATION);
+        }
+        return d;
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtilForEvent.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtilForEvent.java
@@ -21,7 +21,7 @@ public class ParserUtilForEvent {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
     public static final String MESSAGE_INVALID_DURATION = "Duration must be in the format D H M S"
-        + " and must be non-negative.";
+        + " where D, H, M and S are all integers.\nThe duration must also be non-negative.";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -124,6 +124,9 @@ public class ParserUtilForEvent {
         String[] trimmedDuration = duration.trim().split(" ");
         Duration d;
         try {
+            if (trimmedDuration.length != 4) {
+                throw new ParseException(MESSAGE_INVALID_DURATION);
+            }
             d = Duration.parse(String.format("P%sDT%sH%sM%s.0S", trimmedDuration[0],
                     trimmedDuration[1], trimmedDuration[2], trimmedDuration[3]));
             if (d.isNegative()) {


### PR DESCRIPTION
Meet command can now set the duration of the meeting. 
This is done by the `duration/` prefix. Prefix is in D H M S, which are any integers. As long as the right number of arguments are supplied, each argument is an integer, and the duration is nonnegative, the duration will be parsed correctly.